### PR TITLE
Move context configuration to toml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 .ruff_cache
 .vscode/
 .github/copilot-instructions.md
+config.toml

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 22.13.1
-python 3.10.5
+python 3.12.9

--- a/osdp/app.py
+++ b/osdp/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+import tomllib
 
 import aws_cdk as cdk
 from pipeline.pipeline_stack import PipelineStack
@@ -9,8 +10,26 @@ from stacks.osdp_prototype_stack import OsdpPrototypeStack
 # Initialize the CDK app which loads the built-in context (from cdk.json and CLI)
 app = cdk.App()
 
+# Load TOML configuration from config.toml
+# This file should be in the same directory as this script
+config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.toml")
+print(f"Looking for config file at: {config_file_path}")
+
+if config_file_path:
+    try:
+        with open(config_file_path, "rb") as f:
+            config = tomllib.load(f)
+
+            # Add config values to context
+            for key, value in config.items():
+                app.node.set_context(key, value)
+    except FileNotFoundError:
+        sys.exit(f"Error: Config file '{config_file_path}' not found.")
+    except tomllib.TOMLDecodeError:
+        sys.exit(f"Error: Config file '{config_file_path}' contains invalid TOML.")
+
 # All the required context keys
-required_context = ["embedding_model_arn", "data"]
+required_context = ["embedding_model_arn", "foundation_model_arn", "data"]
 
 # Validate that each required context is provided
 for key in required_context:
@@ -41,33 +60,28 @@ if data_type == "ead":
             "Please provide 'bucket' and 'prefix' in the 'data.s3' context object."
         )
 
-# Try to get a stack prefix value from the env or CDK context (CLI or cdk.json)
+# Try to get a stack prefix value from the env or the config file
 # For NU developers this will use or DEV_PREFIX env var
+# unless overridden in the config.toml file
 stack_prefix = os.environ.get("DEV_PREFIX") or app.node.try_get_context("stack_prefix")
 
 if not stack_prefix:
-    print("No stack_prefix found in CDK context. Exiting.")
-    print("Please set using the cli.")
-    print("Example: cdk deploy -c stack_prefix=alice")
+    print("No stack_prefix found in CDK context or environment. Exiting.")
+    print("Please set stack prefix in the config.toml file.")
     exit(1)
 
+# Set the stack_prefix in context so constructs can access it without direct passing
+app.node.set_context("stack_prefix", stack_prefix)
 
 OsdpPrototypeStack(
     app,
     f"{stack_prefix}-OSDP-Prototype",
-    stack_prefix=stack_prefix,
-    # If you don't specify 'env', this stack will be environment-agnostic.
-    # Account/Region-dependent features and context lookups will not work,
-    # but a single synthesized template can be deployed anywhere.
+    env=cdk.Environment(account=os.getenv("CDK_DEFAULT_ACCOUNT"), region=os.getenv("CDK_DEFAULT_REGION")),
     # Uncomment the next line to specialize this stack for the AWS Account
     # and Region that are implied by the current CLI configuration.
-    env=cdk.Environment(account=os.getenv("CDK_DEFAULT_ACCOUNT"), region=os.getenv("CDK_DEFAULT_REGION")),
-    # Uncomment the next line if you know exactly what Account and Region you
-    # want to deploy the stack to. */
     # env=cdk.Environment(account='123456789012', region='us-east-1'),
     # For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
 )
-PipelineStack(
-    app, "OsdpPipelineStack", stack_prefix="staging", env=cdk.Environment(account="625046682746", region="us-east-1")
-)
+
+PipelineStack(app, "OsdpPipelineStack", env=cdk.Environment(account="625046682746", region="us-east-1"))
 app.synth()

--- a/osdp/cdk.json
+++ b/osdp/cdk.json
@@ -15,17 +15,6 @@
     ]
   },
   "context": {
-    "data": {
-        "type": "iiif",
-        "collection_url": "https://api.dc.library.northwestern.edu/api/v2/collections/ecacd539-fe38-40ec-bbc0-590acee3d4f2?as=iiif"
-    },
-    "embedding_model_arn": "arn:aws:bedrock:us-east-1::foundation-model/cohere.embed-multilingual-v3",
-    "foundation_model_arn": "arn:aws:bedrock:us-east-1:625046682746:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "manifest_fetch_concurrency": 15,
-    "ead_process_concurrency": 10,
-    "tags": {
-      "project": "imls-grant"
-    },
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
     "@aws-cdk/core:target-partitions": [

--- a/osdp/config.toml.example
+++ b/osdp/config.toml.example
@@ -1,0 +1,20 @@
+stack_prefix = "my-stack"
+embedding_model_arn = ""
+foundation_model_arn = ""
+manifest_fetch_concurrency = 15
+ead_process_concurrency = 10
+
+[data]
+type = "iiif"
+collection_url = "https://api.dc.library.northwestern.edu/api/v2/collections/ecacd539-fe38-40ec-bbc0-590acee3d4f2?as=iiif"
+
+# Alternatively, for EAD data use the following structure
+# [data]
+# type = "ead"
+
+# [data.s3]
+# bucket = "my-bucket"
+# prefix = "my-prefix
+
+[tags]
+project = "my-project"

--- a/osdp/constructs/api_construct.py
+++ b/osdp/constructs/api_construct.py
@@ -28,13 +28,15 @@ class ApiConstruct(Construct):
         scope: Construct,
         id: str,
         knowledge_base: str,
-        stack_prefix: str,
         model_arn: str,
         amplify_app: amplify.App,
-        allowed_origins: List[str],  # Add this parameter
+        allowed_origins: List[str],
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
+
+        # Get stack_prefix from context
+        stack_prefix = self.node.try_get_context("stack_prefix")
 
         # Create a Cognito User Pool
         self.user_pool = cognito.UserPool(

--- a/osdp/constructs/knowledge_base_construct.py
+++ b/osdp/constructs/knowledge_base_construct.py
@@ -15,11 +15,13 @@ class KnowledgeBaseConstruct(Construct):
         db_cluster: str,
         db_credentials: str,
         embedding_model_arn: str,
-        stack_prefix: str,
         db_initialization: str,
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
+
+        # Get stack_prefix from context
+        stack_prefix = self.node.try_get_context("stack_prefix")
 
         # Create IAM role for the Knowledge Base
         kb_role = iam.Role(

--- a/osdp/pipeline/osdp_application_stage.py
+++ b/osdp/pipeline/osdp_application_stage.py
@@ -5,7 +5,7 @@ from stacks.osdp_prototype_stack import OsdpPrototypeStack
 
 
 class OsdpApplicationStage(Stage):
-    def __init__(self, scope: Construct, id: str, stack_prefix: str, **kwargs):
+    def __init__(self, scope: Construct, id: str, **kwargs):
         super().__init__(scope, id, **kwargs)
 
         github_action_arn = f"arn:aws:iam::{self.account}:oidc-provider/token.actions.githubusercontent.com"
@@ -15,4 +15,4 @@ class OsdpApplicationStage(Stage):
             conditions={"StringLike": {"token.actions.githubusercontent.com:sub": "repo:nulib/osdp-prototype-ui:*"}},
         )
 
-        OsdpPrototypeStack(self, "OSDP-Prototype", stack_prefix=stack_prefix, ui_function_invoke_principal=principal)
+        OsdpPrototypeStack(self, "OSDP-Prototype", ui_function_invoke_principal=principal)

--- a/osdp/pipeline/pipeline_stack.py
+++ b/osdp/pipeline/pipeline_stack.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 import aws_cdk as cdk
 from aws_cdk import SecretValue, pipelines
+from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 from pipeline.osdp_application_stage import OsdpApplicationStage
 
 
 class PipelineStack(cdk.Stack):
-    def __init__(self, scope: Construct, construct_id: str, stack_prefix: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         # Define the CodePipeline source
@@ -16,21 +17,27 @@ class PipelineStack(cdk.Stack):
             authentication=SecretValue.secrets_manager("osdp/github-token"),
         )
 
+        # Get stack_prefix and other configs from parameter store
+        # The parameter in SSM contains the complete CLI parameters string
+        config_param = ssm.StringParameter.from_string_parameter_name(self, "ConfigParam", "/osdp/staging/config")
+
         # Define the synth step.
-        # Pass the context parameters including stack_prefix set to "staging".
+        # Use the parameter value directly from SSM
         synth = pipelines.ShellStep(
             "Synth",
             input=source,
             commands=[
                 "npm install -g aws-cdk",
                 "pip install uv",
+                "sudo dnf install -y libxcrypt-compat || true",
                 "uv sync --no-dev",
                 ". .venv/bin/activate",
                 "cd osdp",
                 "cdk --version",
-                f"cdk synth -c stack_prefix={stack_prefix}",
+                "cdk synth $(node -e \"console.log(process.env.CONFIG_PARAM || '')\")",
             ],
             primary_output_directory="osdp/cdk.out",
+            env={"CONFIG_PARAM": config_param.string_value},
         )
 
         # Define the CodePipeline using CDK Pipelines
@@ -74,7 +81,8 @@ class PipelineStack(cdk.Stack):
         )
 
         # Define the application stages
+        # The stack_prefix will be passed through the context by the synth step
         deploy_stage = OsdpApplicationStage(
-            self, "staging", stack_prefix=stack_prefix, env=cdk.Environment(account="625046682746", region="us-east-1")
+            self, "staging", env=cdk.Environment(account="625046682746", region="us-east-1")
         )
         pipeline.add_stage(deploy_stage)

--- a/osdp/stacks/osdp_prototype_stack.py
+++ b/osdp/stacks/osdp_prototype_stack.py
@@ -27,7 +27,6 @@ class OsdpPrototypeStack(Stack):
         self,
         scope: Construct,
         construct_id: str,
-        stack_prefix: str,
         ui_function_invoke_principal: Optional[iam.WebIdentityPrincipal] = None,
         **kwargs,
     ) -> None:
@@ -75,8 +74,7 @@ class OsdpPrototypeStack(Stack):
             embedding_model_arn=self.node.try_get_context("embedding_model_arn"),
             db_cluster=database_construct.db_cluster,
             db_credentials=database_construct.db_credentials,
-            stack_prefix=stack_prefix,
-            db_initialization=database_construct.db_init3_index,
+            db_initialization=database_construct.db_init4_index,
         )
 
         # Create the Amplify app first so we have the id
@@ -100,7 +98,6 @@ class OsdpPrototypeStack(Stack):
             self,
             "ApiConstruct",
             knowledge_base=knowledge_base_construct.knowledge_base,
-            stack_prefix=stack_prefix,
             model_arn=self.node.try_get_context("foundation_model_arn"),
             allowed_origins=[ui_domain, "localhost:3000"],  # TODO change when custom domain?
             amplify_app=amplify_app,

--- a/osdp/tests/unit/test_api.py
+++ b/osdp/tests/unit/test_api.py
@@ -19,9 +19,7 @@ def stack_and_template():
         "foundation_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
     )
     app.node.set_context("aws:cdk:bundling-stacks", [])  # Disable bundling to speed up tests
-    stack = OsdpPrototypeStack(
-        app, "alice-OSDP-Prototype", stack_prefix=STACK_PREFIX, env={"account": "123456789012", "region": "us-east-1"}
-    )
+    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
     return stack, template
 

--- a/osdp/tests/unit/test_database.py
+++ b/osdp/tests/unit/test_database.py
@@ -17,9 +17,7 @@ def stack_and_template():
         "foundation_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
     )
     app.node.set_context("aws:cdk:bundling-stacks", [])  # Disable bundling to speed up tests
-    stack = OsdpPrototypeStack(
-        app, "alice-OSDP-Prototype", stack_prefix="alice", env={"account": "123456789012", "region": "us-east-1"}
-    )
+    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
     return stack, template
 
@@ -30,7 +28,7 @@ def test_aurora_cluster_created(stack_and_template):
         "AWS::RDS::DBCluster",
         {
             "Engine": "aurora-postgresql",
-            "EngineVersion": assertions.Match.string_like_regexp("15.3"),
+            "EngineVersion": assertions.Match.string_like_regexp("16.6"),
             "ServerlessV2ScalingConfiguration": {"MinCapacity": 0.5, "MaxCapacity": 8},
             "EnableHttpEndpoint": True,
         },

--- a/osdp/tests/unit/test_knowledge_base.py
+++ b/osdp/tests/unit/test_knowledge_base.py
@@ -18,9 +18,7 @@ def stack_and_template():
     )
 
     app.node.set_context("aws:cdk:bundling-stacks", [])  # Disable bundling to speed up tests
-    stack = OsdpPrototypeStack(
-        app, "alice-OSDP-Prototype", stack_prefix="alice", env={"account": "123456789012", "region": "us-east-1"}
-    )
+    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
     return stack, template
 

--- a/osdp/tests/unit/test_source_stack.py
+++ b/osdp/tests/unit/test_source_stack.py
@@ -18,9 +18,7 @@ def stack_and_template():
         "foundation_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
     )
     app.node.set_context("aws:cdk:bundling-stacks", [])  # Disable bundling to speed up tests
-    stack = OsdpPrototypeStack(
-        app, "alice-OSDP-Prototype", stack_prefix="alice", env={"account": "123456789012", "region": "us-east-1"}
-    )
+    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
     return stack, template
 
@@ -127,7 +125,6 @@ def test_function_invoker_role_created():
     stack = OsdpPrototypeStack(
         app,
         "alice-OSDP-Prototype",
-        stack_prefix="alice",
         ui_function_invoke_principal=principal,
         env={"account": "123456789012", "region": "us-east-1"},
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "osdp-prototype"
 readme = "README.md"
 version = "0.1.0"
-requires-python = "==3.10.5"
+requires-python = "==3.12.9"
 dependencies = [
     "aws-cdk-aws-amplify-alpha>=2.181.0a0",
     "aws-cdk-lib>=2.181.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = "==3.10.5"
+requires-python = "==3.12.9"
 
 [[package]]
 name = "attrs"
@@ -121,8 +121,6 @@ version = "24.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "exceptiongroup" },
-    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/65/af6d57da2cb32c076319b7489ae0958f746949d407109e3ccf4d115f147c/cattrs-24.1.2.tar.gz", hash = "sha256:8028cfe1ff5382df59dd36474a86e02d817b06eaf8af84555441bac915d2ef85", size = 426462 }
 wheels = [
@@ -144,19 +142,19 @@ version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/58/5580c1716040bc89206c77d8f74418caf82ce519aae06450393ca73475d1/charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de", size = 198013 },
-    { url = "https://files.pythonhosted.org/packages/d0/11/00341177ae71c6f5159a08168bcb98c6e6d196d372c94511f9f6c9afe0c6/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176", size = 141285 },
-    { url = "https://files.pythonhosted.org/packages/01/09/11d684ea5819e5a8f5100fb0b38cf8d02b514746607934134d31233e02c8/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037", size = 151449 },
-    { url = "https://files.pythonhosted.org/packages/08/06/9f5a12939db324d905dc1f70591ae7d7898d030d7662f0d426e2286f68c9/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f", size = 143892 },
-    { url = "https://files.pythonhosted.org/packages/93/62/5e89cdfe04584cb7f4d36003ffa2936681b03ecc0754f8e969c2becb7e24/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a", size = 146123 },
-    { url = "https://files.pythonhosted.org/packages/a9/ac/ab729a15c516da2ab70a05f8722ecfccc3f04ed7a18e45c75bbbaa347d61/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a", size = 147943 },
-    { url = "https://files.pythonhosted.org/packages/03/d2/3f392f23f042615689456e9a274640c1d2e5dd1d52de36ab8f7955f8f050/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247", size = 142063 },
-    { url = "https://files.pythonhosted.org/packages/f2/e3/e20aae5e1039a2cd9b08d9205f52142329f887f8cf70da3650326670bddf/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408", size = 150578 },
-    { url = "https://files.pythonhosted.org/packages/8d/af/779ad72a4da0aed925e1139d458adc486e61076d7ecdcc09e610ea8678db/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb", size = 153629 },
-    { url = "https://files.pythonhosted.org/packages/c2/b6/7aa450b278e7aa92cf7732140bfd8be21f5f29d5bf334ae987c945276639/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d", size = 150778 },
-    { url = "https://files.pythonhosted.org/packages/39/f4/d9f4f712d0951dcbfd42920d3db81b00dd23b6ab520419626f4023334056/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807", size = 146453 },
-    { url = "https://files.pythonhosted.org/packages/49/2b/999d0314e4ee0cff3cb83e6bc9aeddd397eeed693edb4facb901eb8fbb69/charset_normalizer-3.4.1-cp310-cp310-win32.whl", hash = "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f", size = 95479 },
-    { url = "https://files.pythonhosted.org/packages/2d/ce/3cbed41cff67e455a386fb5e5dd8906cdda2ed92fbc6297921f2e4419309/charset_normalizer-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f", size = 102790 },
+    { url = "https://files.pythonhosted.org/packages/0a/9a/dd1e1cdceb841925b7798369a09279bd1cf183cef0f9ddf15a3a6502ee45/charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545", size = 196105 },
+    { url = "https://files.pythonhosted.org/packages/d3/8c/90bfabf8c4809ecb648f39794cf2a84ff2e7d2a6cf159fe68d9a26160467/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7", size = 140404 },
+    { url = "https://files.pythonhosted.org/packages/ad/8f/e410d57c721945ea3b4f1a04b74f70ce8fa800d393d72899f0a40526401f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757", size = 150423 },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/e6825e25deb691ff98cf5c9072ee0605dc2acfca98af70c2d1b1bc75190d/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa", size = 143184 },
+    { url = "https://files.pythonhosted.org/packages/3e/a2/513f6cbe752421f16d969e32f3583762bfd583848b763913ddab8d9bfd4f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d", size = 145268 },
+    { url = "https://files.pythonhosted.org/packages/74/94/8a5277664f27c3c438546f3eb53b33f5b19568eb7424736bdc440a88a31f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616", size = 147601 },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/6d352c51ee763623a98e31194823518e09bfa48be2a7e8383cf691bbb3d0/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b", size = 141098 },
+    { url = "https://files.pythonhosted.org/packages/78/d4/f5704cb629ba5ab16d1d3d741396aec6dc3ca2b67757c45b0599bb010478/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d", size = 149520 },
+    { url = "https://files.pythonhosted.org/packages/c5/96/64120b1d02b81785f222b976c0fb79a35875457fa9bb40827678e54d1bc8/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a", size = 152852 },
+    { url = "https://files.pythonhosted.org/packages/84/c9/98e3732278a99f47d487fd3468bc60b882920cef29d1fa6ca460a1fdf4e6/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9", size = 150488 },
+    { url = "https://files.pythonhosted.org/packages/13/0e/9c8d4cb99c98c1007cc11eda969ebfe837bbbd0acdb4736d228ccaabcd22/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1", size = 146192 },
+    { url = "https://files.pythonhosted.org/packages/b2/21/2b6b5b860781a0b49427309cb8670785aa543fb2178de875b87b9cc97746/charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35", size = 95550 },
+    { url = "https://files.pythonhosted.org/packages/21/5b/1b390b03b1d16c7e382b561c5329f83cc06623916aab983e8ab9239c7d5c/charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f", size = 102785 },
     { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767 },
 ]
 
@@ -193,15 +191,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/84/f608a0a71a05a476b2f1761ab8f3f776677d39f7996ecf1092a1ce741a7c/constructs-10.4.2.tar.gz", hash = "sha256:ce54724360fffe10bab27d8a081844eb81f5ace7d7c62c84b719c49f164d5307", size = 65434 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/d9/c5e7458f323bf063a9a54200742f2494e2ce3c7c6873e0ff80f88033c75f/constructs-10.4.2-py3-none-any.whl", hash = "sha256:1f0f59b004edebfde0f826340698b8c34611f57848139b7954904c61645f13c1", size = 63509 },
-]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453 },
 ]
 
 [[package]]
@@ -310,6 +299,7 @@ dev = [
     { name = "ruff" },
 ]
 iiif = [
+    { name = "boto3" },
     { name = "loam-iiif" },
 ]
 
@@ -326,7 +316,10 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.9.7" },
 ]
-iiif = [{ name = "loam-iiif", specifier = ">=0.1.3" }]
+iiif = [
+    { name = "boto3", specifier = ">=1.37.1" },
+    { name = "loam-iiif", specifier = ">=0.1.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -370,11 +363,9 @@ version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
@@ -415,7 +406,6 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
 wheels = [
@@ -466,15 +456,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
-]
-
-[[package]]
-name = "tomli"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary 

Move configuration out of `cdk.json` and into a `toml` file which can be stored outside the Github repo. The staging pipeline uses AWS Parameter Store.

# Changes in this PR

- Upgade Python to `3.12.x`
- Reads a configuration file from `osdp/config.toml` and loads values into cdk context, replacing values hard coded in `cdk.json` and/or provided on the command line
- Uses AWS Parameter store for context values for the[ staging PipelineStack](https://github.com/nulib/tfvars/blob/main/treetop/osdp-config-staging.txt)
- Upgrades Aurora Serverless to `16.6` and `pgvector` to > `5.1` which allows/requires us to use `hnsw` instead of `ivfflat`. ( _this was currently broken - it looked like Bedrock had been upgraded to expect this and the deploy was failing_.)
   - Note: this upgrade seems to produce sub-optimal search results, which we will need to address in upcoming work. I'm seeing things like: `Q: What's in the collection?` -> `A: I cannot provide specific informaiton about what is in the collection based on the given search results. While the results indicate these are from the Northwestern University Libraries Digital Collections, they only contain technical metadata and API information rather than details about the collection content. `
- Update `README.md`

# Testing

- Symlink the configuration file from `nulib/tfvars` to [`osdp/config.toml`](https://github.com/nulib/tfvars/blob/main/treetop/config.toml) - adjust any values as desired
- Install/upgrade Python as needed and update dependencies.
- note: you may need `sudo dnf install libxcrypt-compat`
- Deploy as usual 