### PR TITLE
Add database configuration to config and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ username = "myapp_db_user"                    # Default: "postgres" - Database u
 ```
 
 **Database Configuration Options:**
-- **Database Name**: Defaults to "treetop" (was previously hardcoded as "postgres")
+- **Database Name**: Defaults to "treetop"
 - **Username**: Defaults to "postgres", can be customized for security
 - **Password**: Auto-generated and stored securely in AWS Secrets Manager
 
@@ -124,7 +124,7 @@ username = "myapp_db_user"                    # Default: "postgres" - Database u
 - Must start with a letter
 - Can only contain letters, numbers, and underscores (no hyphens, spaces, or special characters)
 - 1-16 characters long
-- Examples: ✅ `myapp_user`, `osdp_bedrock_user` | ❌ `my-app-user`, `user@domain`
+- Examples: ✅ `myapp_user`, `treetop_bedrock_user` | ❌ `my-app-user`, `user@domain`
 
 **Security Benefits:**
 - Uses descriptive database name "treetop" instead of generic "postgres"

--- a/README.md
+++ b/README.md
@@ -96,6 +96,42 @@ project = "my-project"
 # Note: ECR section not required for EAD workflows
 ```
 
+#### Database Configuration (Optional)
+
+You can customize the database name and credentials for enhanced security:
+
+```toml
+# Database configuration (optional)
+[database]
+name = "treetop"                              # Default: "treetop" - Database name
+[database.credentials]
+username = "myapp_db_user"                    # Default: "postgres" - Database username
+# password_exclude_chars defaults to '"\'@/\' - characters excluded from auto-generated passwords
+```
+
+**Database Configuration Options:**
+- **Database Name**: Defaults to "treetop" (was previously hardcoded as "postgres")
+- **Username**: Defaults to "postgres", can be customized for security
+- **Password**: Auto-generated and stored securely in AWS Secrets Manager
+
+**Database Name Requirements:**
+- Must start with a letter
+- Can only contain letters and numbers (no hyphens, underscores, spaces, or special characters)
+- 1-63 characters long
+- Examples: ✅ `treetop`, `myproject`, `treetopabc` | ❌ `tree-top`, `tree_top`, `my project`
+
+**Database Username Requirements:**
+- Must start with a letter
+- Can only contain letters, numbers, and underscores (no hyphens, spaces, or special characters)
+- 1-16 characters long
+- Examples: ✅ `myapp_user`, `osdp_bedrock_user` | ❌ `my-app-user`, `user@domain`
+
+**Security Benefits:**
+- Uses descriptive database name "treetop" instead of generic "postgres"
+- Uses service-specific usernames instead of generic "postgres"
+- AWS automatically generates secure passwords with configurable character exclusions
+- Passwords are stored in AWS Secrets Manager and never exposed in configuration
+
 **Required Configuration Changes:**
 - `stack_prefix`: Choose a unique name for your deployment (e.g., "my-treetop")
 - **Account ID**: Replace `123456789012` in the `foundation_model_arn` (inference profile) with your AWS account ID
@@ -241,6 +277,7 @@ After deployment completes check the bottom for relevant stack outputs (if you m
 - `ApiUrl`: Your API Gateway endpoint URL
 - `UserPoolId`: Cognito User Pool ID (needed for creating users)
 - `KnowledgeBaseId`: Bedrock Knowledge Base ID
+- `DatabaseName`: Database name (defaults to "treetop")
 
 > [!TIP]
 > Save the `UserPoolId` and `UserPoolIdWebsite URL` from outputs. You'll need the `UserPoolId` to create Cognito users in the next step. `Website URL` is your application URL which can be retrieved manually by following step 6 below.

--- a/config.toml.example
+++ b/config.toml.example
@@ -25,3 +25,11 @@ project = "my-project"
 # registry = "public.ecr.aws"                    # Default: "public.ecr.aws"
 # repository = "nulib-staging/osdp-iiif-fetcher" # Default: "nulib-staging/osdp-iiif-fetcher"
 # tag = "latest"                                 # Default: "latest"
+
+# Database configuration (optional)
+# Uncomment and modify the following section only if you need to override the default database settings
+# [database]
+# name = "treetop"                              # Default: "treetop" - Database name
+# [database.credentials]
+# username = "postgres"                         # Default: "postgres" - Database username
+# password_exclude_chars = '"\'@/\\'            # Default: '"\'@/\' - Characters to exclude from generated password

--- a/config.toml.example
+++ b/config.toml.example
@@ -22,9 +22,9 @@ project = "my-project"
 # ECR configuration (optional - uses defaults shown below)
 # Uncomment and modify the following section only if you need to override the default ECR settings
 # [ecr]
-# registry = "public.ecr.aws"                    # Default: "public.ecr.aws"
-# repository = "nulib-staging/osdp-iiif-fetcher" # Default: "nulib-staging/osdp-iiif-fetcher"
-# tag = "latest"                                 # Default: "latest"
+# registry = "public.ecr.aws"                      # Default: "public.ecr.aws"
+# repository = "nulib-staging/treetop-iiif-fetcher" # Default: "nulib-staging/treetop-iiif-fetcher"
+# tag = "latest"                                   # Default: "latest"
 
 # Database configuration (optional)
 # Uncomment and modify the following section only if you need to override the default database settings

--- a/iiif/README.md
+++ b/iiif/README.md
@@ -1,4 +1,4 @@
-# OSDP - Docker image to fetch IIIF manifests
+# Treetop - Docker image to fetch IIIF manifests
 
 ## Deployment
 
@@ -6,7 +6,7 @@ Deployment is handled via the `deploy-ecr.yml` Github Action.
 
 ## Local Development
 
-To run the script locally, you can use the following commands:
+To run the script locally, you can use the following commands from the `iiif/` directory:
 
 ```bash
 export COLLECTION_URL="http://example.com/collection"

--- a/src/treetop/constructs/knowledge_base_construct.py
+++ b/src/treetop/constructs/knowledge_base_construct.py
@@ -16,9 +16,16 @@ class KnowledgeBaseConstruct(Construct):
         db_credentials: str,
         embedding_model_arn: str,
         db_initialization: str,
+        db_config: dict = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
+
+        # Set default database configuration
+        default_db_config = {"name": "treetop"}
+        self.db_config = default_db_config.copy()
+        if db_config:
+            self.db_config.update(db_config)
 
         # Get stack_prefix from context
         stack_prefix = self.node.try_get_context("stack_prefix") or ""
@@ -87,7 +94,7 @@ class KnowledgeBaseConstruct(Construct):
                 type="RDS",
                 rds_configuration=bedrock.CfnKnowledgeBase.RdsConfigurationProperty(
                     credentials_secret_arn=db_credentials.secret_arn,
-                    database_name="postgres",
+                    database_name=self.db_config["name"],
                     resource_arn=db_cluster.cluster_arn,
                     table_name="bedrock_integration.bedrock_knowledge_base",
                     field_mapping=bedrock.CfnKnowledgeBase.RdsFieldMappingProperty(

--- a/src/treetop/functions/build_function/README.md
+++ b/src/treetop/functions/build_function/README.md
@@ -1,6 +1,6 @@
 # build_function
 
-A function triggered by a custom CloudFormation Event that build the OSDP UI from source.
+A function triggered by a custom CloudFormation Event that build the Treetop UI from source.
 
 ## development
 

--- a/src/treetop/stacks/treetop_stack.py
+++ b/src/treetop/stacks/treetop_stack.py
@@ -79,7 +79,8 @@ class TreetopStack(Stack):
             ecs_construct = EcsConstruct(self, "EcsConstruct", data_bucket=data_bucket, ecr_image=ecr_image_uri)
 
         # Database construct
-        database_construct = DatabaseConstruct(self, "DatabaseConstruct")
+        db_config = self.node.try_get_context("database")
+        database_construct = DatabaseConstruct(self, "DatabaseConstruct", db_config=db_config)
 
         # Knowledge Base construct
         knowledge_base_construct = KnowledgeBaseConstruct(
@@ -90,6 +91,7 @@ class TreetopStack(Stack):
             db_cluster=database_construct.db_cluster,
             db_credentials=database_construct.db_credentials,
             db_initialization=database_construct.db_init4_index,
+            db_config=db_config,
         )
 
         # Create the Amplify app first so we have the id

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -81,7 +81,7 @@ def test_db_credentials_created_with_custom_config():
     )
     app.node.set_context("database", {"credentials": {"username": "myuser", "password_exclude_chars": "!@#$%^&*()"}})
     app.node.set_context("aws:cdk:bundling-stacks", [])
-    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
+    stack = TreetopStack(app, "alice-Treetop", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
 
     template.has_resource_properties(
@@ -109,7 +109,7 @@ def test_db_credentials_created_with_partial_config():
     )
     app.node.set_context("database", {"credentials": {"username": "customuser"}})
     app.node.set_context("aws:cdk:bundling-stacks", [])
-    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
+    stack = TreetopStack(app, "alice-Treetop", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
 
     template.has_resource_properties(
@@ -136,7 +136,7 @@ def test_db_credentials_created_with_no_database_config():
         "foundation_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
     )
     app.node.set_context("aws:cdk:bundling-stacks", [])
-    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
+    stack = TreetopStack(app, "alice-Treetop", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
 
     template.has_resource_properties(
@@ -162,16 +162,16 @@ def test_db_credentials_with_only_username_override():
     app.node.set_context(
         "foundation_model_arn", "arn:aws:sagemaker:us-east-1:123456789012:model/bedrock-embedding-model"
     )
-    app.node.set_context("database", {"credentials": {"username": "osdp_user"}})
+    app.node.set_context("database", {"credentials": {"username": "treetop_user"}})
     app.node.set_context("aws:cdk:bundling-stacks", [])
-    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
+    stack = TreetopStack(app, "alice-Treetop", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
 
     template.has_resource_properties(
         "AWS::SecretsManager::Secret",
         {
             "GenerateSecretString": {
-                "SecretStringTemplate": '{"username": "osdp_user"}',
+                "SecretStringTemplate": '{"username": "treetop_user"}',
                 "GenerateStringKey": "password",
                 "ExcludeCharacters": "\"'@/\\",
             }
@@ -192,7 +192,7 @@ def test_db_credentials_with_only_password_exclude_chars_override():
     )
     app.node.set_context("database", {"credentials": {"password_exclude_chars": "!@#$%"}})
     app.node.set_context("aws:cdk:bundling-stacks", [])
-    stack = OsdpPrototypeStack(app, "alice-OSDP-Prototype", env={"account": "123456789012", "region": "us-east-1"})
+    stack = TreetopStack(app, "alice-Treetop", env={"account": "123456789012", "region": "us-east-1"})
     template = assertions.Template.from_stack(stack)
 
     template.has_resource_properties(


### PR DESCRIPTION
## Description

- Add database configuration to config and update README
  - database name (default: `treetop`)
  - database username (default: `postgres`)
  - password exclude characters (default: `'"\'@/\'`)

## Steps to test
- Check the `Database Configuration` section of the README for the new toml configuration options
- Teardown any existing stacks and deploy a new one with updated configs
- Check the `cdk deploy` outputs:

<img width="1166" height="221" alt="treetop_outputs" src="https://github.com/user-attachments/assets/c9973b70-8212-49b1-a47b-fbf49c48ddfa" />

Working example with custom db configs:
<img width="898" height="632" alt="treetop_test" src="https://github.com/user-attachments/assets/65cb76db-9d26-497d-94bb-4b9bf938fb14" />
